### PR TITLE
Dependent Fields (`get` utility)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,6 @@
   "javascript.preferences.importModuleSpecifier": "relative",
   "typescript.preferences.importModuleSpecifierEnding": "js",
   "javascript.preferences.importModuleSpecifierEnding": "js",
-  "vitest.commandLine": "npm run test --"
+  "vitest.commandLine": "npm run test --",
+  "typescript.preferences.autoImportFileExcludePatterns": ["@types/node/test.d.ts"]
 }

--- a/src/field-resolver.test.ts
+++ b/src/field-resolver.test.ts
@@ -3,37 +3,40 @@ import { type FieldResolver, type ResolvedFields, type ResolvedField, Lazy, lazy
 
 it('Lazy', async () => {
   const lazy1 = new Lazy(({ seq }) => `Book-${seq}`);
-  expect(await lazy1.get({ seq: 0 })).toBe('Book-0');
+  expect(await lazy1.get({ seq: 0, get: async () => Promise.resolve() })).toBe('Book-0');
 
   const lazy2 = new Lazy(async ({ seq }) => Promise.resolve(`Book-${seq}`));
-  expect(await lazy2.get({ seq: 0 })).toBe('Book-0');
+  expect(await lazy2.get({ seq: 0, get: async () => Promise.resolve() })).toBe('Book-0');
 });
 
 it('lazy', async () => {
   const l1 = lazy(({ seq }) => `Book-${seq}`);
   expect(l1).instanceOf(Lazy);
-  expect(await l1.get({ seq: 0 })).toBe('Book-0');
+  expect(await l1.get({ seq: 0, get: async () => Promise.resolve() })).toBe('Book-0');
 
   const l2 = lazy(async ({ seq }) => Promise.resolve(`Book-${seq}`));
   expect(l2).instanceOf(Lazy);
-  expect(await l2.get({ seq: 0 })).toBe('Book-0');
+  expect(await l2.get({ seq: 0, get: async () => Promise.resolve() })).toBe('Book-0');
 });
 
 it('FieldResolver', () => {
-  expectTypeOf<FieldResolver<number>>().toEqualTypeOf<number | Lazy<number>>();
+  type Type = { a: number };
+  expectTypeOf<FieldResolver<Type, Type['a']>>().toEqualTypeOf<number | Lazy<{ a: number }, number>>();
 });
 
 it('ResolvedField', () => {
+  type Type = { a: number };
   expectTypeOf<ResolvedField<number>>().toEqualTypeOf<number>();
-  expectTypeOf<ResolvedField<Lazy<number>>>().toEqualTypeOf<number>();
+  expectTypeOf<ResolvedField<Lazy<Type, Type['a']>>>().toEqualTypeOf<number>();
 });
 
 it('ResolvedFields', () => {
+  type Type = { a: number };
   expectTypeOf<
     ResolvedFields<{
-      a: FieldResolver<number>;
-      b: FieldResolver<undefined>;
-      c: FieldResolver<number | undefined>;
+      a: FieldResolver<Type, number>;
+      b: FieldResolver<Type, undefined>;
+      c: FieldResolver<Type, number | undefined>;
     }>
   >().toEqualTypeOf<{
     a: number;
@@ -42,5 +45,4 @@ it('ResolvedFields', () => {
   }>();
 });
 
-it.todo('resolveField');
 it.todo('resolveFields');

--- a/src/field-resolver.ts
+++ b/src/field-resolver.ts
@@ -63,14 +63,14 @@ export async function resolveFields<
   async function resolveFieldAndUpdateCache<FieldName extends keyof Type>(
     fieldName: FieldName,
   ): Promise<Type[FieldName]> {
-    if (!(fieldName in fields)) {
-      if (fieldName in inputFieldsResolver) {
-        // eslint-disable-next-line require-atomic-updates, no-await-in-loop -- The fields are resolved sequentially, so there is no possibility of a race condition.
-        fields[fieldName] = await resolveField(options, inputFieldsResolver[fieldName]);
-      } else {
-        // eslint-disable-next-line require-atomic-updates, no-await-in-loop -- The fields are resolved sequentially, so there is no possibility of a race condition.
-        fields[fieldName] = await resolveField(options, defaultFieldsResolver[fieldName]);
-      }
+    if (fieldName in fields) return fields[fieldName];
+
+    if (fieldName in inputFieldsResolver) {
+      // eslint-disable-next-line require-atomic-updates, no-await-in-loop -- The fields are resolved sequentially, so there is no possibility of a race condition.
+      fields[fieldName] = await resolveField(options, inputFieldsResolver[fieldName]);
+    } else {
+      // eslint-disable-next-line require-atomic-updates, no-await-in-loop -- The fields are resolved sequentially, so there is no possibility of a race condition.
+      fields[fieldName] = await resolveField(options, defaultFieldsResolver[fieldName]);
     }
     return fields[fieldName];
   }

--- a/src/field-resolver.ts
+++ b/src/field-resolver.ts
@@ -1,62 +1,89 @@
 import { DeepOptional, Merge } from './util.js';
 
-export type FieldResolverOptions = {
+export type FieldResolverOptions<Type> = {
   seq: number;
+  get: <FieldName extends keyof Type>(fieldName: FieldName) => Promise<Type[FieldName]>;
 };
 
-export class Lazy<T> {
-  constructor(private readonly factory: (options: FieldResolverOptions) => T | Promise<T>) {}
-  async get(options: FieldResolverOptions): Promise<T> {
+export class Lazy<Type, Field> {
+  constructor(private readonly factory: (options: FieldResolverOptions<Type>) => Field | Promise<Field>) {}
+  async get(options: FieldResolverOptions<Type>): Promise<Field> {
     return this.factory(options);
   }
 }
 /** Wrapper to delay field generation until needed. */
-export function lazy<T>(factory: (options: FieldResolverOptions) => T | Promise<T>): Lazy<T> {
+export function lazy<Type, Field>(
+  factory: (options: FieldResolverOptions<Type>) => Field | Promise<Field>,
+): Lazy<Type, Field> {
   return new Lazy(factory);
 }
 
-export type FieldResolver<Field> = Field | Lazy<Field>;
+export type FieldResolver<Type, Field> = Field | Lazy<Type, Field>;
 /** The type of `inputFields` option of `build` method. */
 export type InputFieldsResolver<Type> = {
-  [Key in keyof Type]?: FieldResolver<DeepOptional<Type>[Key]>;
+  [FieldName in keyof Type]?: FieldResolver<Type, DeepOptional<Type>[FieldName]>;
 };
 /** The type of `defaultFields` option of `defineFactory` function. */
 export type DefaultFieldsResolver<Type> = {
-  [Key in keyof Type]: FieldResolver<DeepOptional<Type>[Key]>;
+  [FieldName in keyof Type]: FieldResolver<Type, DeepOptional<Type>[FieldName]>;
 };
 
-export type ResolvedField<T extends FieldResolver<unknown>> = T extends FieldResolver<infer R> ? R : never;
-
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export type ResolvedField<T extends FieldResolver<unknown, unknown>> = T extends FieldResolver<infer _, infer R>
+  ? R
+  : never;
 /** Convert `{ a: number, b: () => number, c: () => Promise<number> }` into `{ a: number, b: number, c: number }`. */
-export type ResolvedFields<FieldsResolver extends Record<string, FieldResolver<unknown>>> = {
+export type ResolvedFields<FieldsResolver extends Record<string, FieldResolver<unknown, unknown>>> = {
   [FieldName in keyof FieldsResolver]: ResolvedField<FieldsResolver[FieldName]>;
 };
-async function resolveField<T>(seq: number, fieldResolver: FieldResolver<T>): Promise<T> {
-  if (fieldResolver instanceof Lazy) {
-    return fieldResolver.get({ seq });
-  } else {
-    return fieldResolver;
-  }
-}
 
 export async function resolveFields<
-  _DefaultFieldsResolver extends DefaultFieldsResolver<unknown>,
-  _InputFieldResolvers extends InputFieldsResolver<unknown>,
+  Type extends Record<string, unknown>,
+  _DefaultFieldsResolver extends DefaultFieldsResolver<Type> = DefaultFieldsResolver<Type>,
+  _InputFieldsResolver extends InputFieldsResolver<Type> = InputFieldsResolver<Type>,
 >(
   seq: number,
-  defaultFieldResolvers: _DefaultFieldsResolver,
-  inputFieldResolvers: _InputFieldResolvers,
-): Promise<Merge<ResolvedFields<_DefaultFieldsResolver>, ResolvedFields<_InputFieldResolvers>>> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  defaultFieldsResolver: _DefaultFieldsResolver,
+  inputFieldsResolver: _InputFieldsResolver,
+): Promise<Merge<ResolvedFields<_DefaultFieldsResolver>, ResolvedFields<_InputFieldsResolver>>> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Use any type as it is impossible to match types.
   const fields: any = {};
-  for (const [key, defaultFieldResolver] of Object.entries(defaultFieldResolvers)) {
-    if (key in inputFieldResolvers) {
-      // eslint-disable-next-line no-await-in-loop
-      fields[key] = await resolveField(seq, inputFieldResolvers[key as keyof _InputFieldResolvers]);
+
+  async function resolveField<Field>(
+    options: FieldResolverOptions<Type>,
+    fieldResolver: FieldResolver<Type, Field>,
+  ): Promise<Field> {
+    if (fieldResolver instanceof Lazy) {
+      return fieldResolver.get(options);
     } else {
-      // eslint-disable-next-line no-await-in-loop
-      fields[key] = await resolveField(seq, defaultFieldResolver);
+      return fieldResolver;
     }
   }
+
+  async function resolveFieldAndUpdateCache<FieldName extends keyof Type>(
+    fieldName: FieldName,
+  ): Promise<Type[FieldName]> {
+    if (!(fieldName in fields)) {
+      if (fieldName in inputFieldsResolver) {
+        // eslint-disable-next-line require-atomic-updates, no-await-in-loop -- The fields are resolved sequentially, so there is no possibility of a race condition.
+        fields[fieldName] = await resolveField(options, inputFieldsResolver[fieldName]);
+      } else {
+        // eslint-disable-next-line require-atomic-updates, no-await-in-loop -- The fields are resolved sequentially, so there is no possibility of a race condition.
+        fields[fieldName] = await resolveField(options, defaultFieldsResolver[fieldName]);
+      }
+    }
+    return fields[fieldName];
+  }
+
+  const options: FieldResolverOptions<Type> = {
+    seq,
+    get: resolveFieldAndUpdateCache,
+  };
+
+  for (const fieldName of Object.keys(defaultFieldsResolver) as (keyof Type)[]) {
+    // eslint-disable-next-line no-await-in-loop
+    await resolveFieldAndUpdateCache(fieldName);
+  }
+
   return fields;
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3,9 +3,21 @@ import { oneOf } from './test/util.js';
 import { defineBookFactory, type Book, resetAllSequence, lazy } from './index.js';
 
 describe('defineTypeFactory', () => {
-  it('basic', async () => {
-    const BookFactory = defineBookFactory({
-      defaultFields: {
+  describe('defaultFields', () => {
+    it('basic', async () => {
+      const BookFactory = defineBookFactory({
+        defaultFields: {
+          id: 'Book-0',
+          title: 'ゆゆ式',
+          author: {
+            id: 'Author-0',
+            name: '三上小又',
+            books: [],
+          },
+        },
+      });
+      const book = await BookFactory.build();
+      expect(book).toStrictEqual({
         id: 'Book-0',
         title: 'ゆゆ式',
         author: {
@@ -13,103 +25,93 @@ describe('defineTypeFactory', () => {
           name: '三上小又',
           books: [],
         },
-      },
-    });
-    const book = await BookFactory.build();
-    expect(book).toStrictEqual({
-      id: 'Book-0',
-      title: 'ゆゆ式',
-      author: {
-        id: 'Author-0',
-        name: '三上小又',
-        books: [],
-      },
-    });
-    assertType<{
-      id: string;
-      title: string;
-      author: {
+      });
+      assertType<{
         id: string;
-        name: string;
-        books: Book[];
-      };
-    }>(book);
-    expectTypeOf(book).not.toBeNever();
-  });
-  it('accepts undefined fields', async () => {
-    const BookFactory = defineBookFactory({
-      defaultFields: {
+        title: string;
+        author: {
+          id: string;
+          name: string;
+          books: Book[];
+        };
+      }>(book);
+      expectTypeOf(book).not.toBeNever();
+    });
+    it('accepts undefined fields', async () => {
+      const BookFactory = defineBookFactory({
+        defaultFields: {
+          id: 'Book-0',
+          title: undefined, // shallow field
+          author: {
+            id: 'Author-0',
+            name: '三上小又',
+            books: undefined, // deep field
+          },
+        },
+      });
+      const book = await BookFactory.build();
+      expect(book).toStrictEqual({
         id: 'Book-0',
-        title: undefined, // shallow field
+        title: undefined,
         author: {
           id: 'Author-0',
           name: '三上小又',
-          books: undefined, // deep field
+          books: undefined,
         },
-      },
-    });
-    const book = await BookFactory.build();
-    expect(book).toStrictEqual({
-      id: 'Book-0',
-      title: undefined,
-      author: {
-        id: 'Author-0',
-        name: '三上小又',
-        books: undefined,
-      },
-    });
-    assertType<{
-      id: string;
-      title: undefined;
-      author: {
+      });
+      assertType<{
         id: string;
-        name: string;
-        books: undefined;
-      };
-    }>(book);
-    expectTypeOf(book).not.toBeNever();
-  });
-  it('accepts functional field resolvers', async () => {
-    const BookFactory = defineBookFactory({
-      defaultFields: {
-        id: lazy(() => 'Book-0'),
-        title: lazy(async () => Promise.resolve('ゆゆ式')),
+        title: undefined;
+        author: {
+          id: string;
+          name: string;
+          books: undefined;
+        };
+      }>(book);
+      expectTypeOf(book).not.toBeNever();
+    });
+    it('accepts functional field resolvers', async () => {
+      const BookFactory = defineBookFactory({
+        defaultFields: {
+          id: lazy(() => 'Book-0'),
+          title: lazy(async () => Promise.resolve('ゆゆ式')),
+          author: undefined,
+        },
+      });
+      const book = await BookFactory.build();
+      expect(book).toStrictEqual({
+        id: 'Book-0',
+        title: 'ゆゆ式',
         author: undefined,
-      },
+      });
+      assertType<{
+        id: string;
+        title: string;
+        author: undefined;
+      }>(book);
+      expectTypeOf(book).not.toBeNever();
     });
-    const book = await BookFactory.build();
-    expect(book).toStrictEqual({
-      id: 'Book-0',
-      title: 'ゆゆ式',
-      author: undefined,
-    });
-    assertType<{
-      id: string;
-      title: string;
-      author: undefined;
-    }>(book);
-    expectTypeOf(book).not.toBeNever();
-  });
-  it('creates fields with sequential id', async () => {
-    const BookFactory = defineBookFactory({
-      defaultFields: {
-        id: lazy(({ seq }) => `Book-${seq}`),
-        title: lazy(async ({ seq }) => Promise.resolve(`ゆゆ式 ${seq}巻`)),
+    it('creates fields with sequential id', async () => {
+      const BookFactory = defineBookFactory({
+        defaultFields: {
+          id: lazy(({ seq }) => `Book-${seq}`),
+          title: lazy(async ({ seq }) => Promise.resolve(`ゆゆ式 ${seq}巻`)),
+          author: undefined,
+        },
+      });
+      const book = await BookFactory.build();
+      expect(book).toStrictEqual({
+        id: 'Book-0',
+        title: 'ゆゆ式 0巻',
         author: undefined,
-      },
+      });
+      assertType<{
+        id: string;
+        title: string;
+        author: undefined;
+      }>(book);
+      expectTypeOf(book).not.toBeNever();
     });
-    const book = await BookFactory.build();
-    expect(book).toStrictEqual({
-      id: 'Book-0',
-      title: 'ゆゆ式 0巻',
-      author: undefined,
-    });
-    assertType<{
-      id: string;
-      title: string;
-      author: undefined;
-    }>(book);
-    expectTypeOf(book).not.toBeNever();
   });
   describe('resetAllSequence', () => {
     it('resets all sequence', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,15 @@ export type Author = {
   books: Book[];
 };
 
+export type User = {
+  id: string;
+  firstName: string;
+  lastName: string;
+  fullName: string;
+};
+
+// ---------- Book ----------
+
 interface BookFactoryDefineOptions {
   defaultFields: DefaultFieldsResolver<Book>;
 }
@@ -61,4 +70,48 @@ export function defineBookFactory<TOptions extends BookFactoryDefineOptions>(
   options: TOptions,
 ): BookFactoryInterface<TOptions> {
   return defineBookFactoryInternal(options);
+}
+
+// ---------- User ----------
+
+interface UserFactoryDefineOptions {
+  defaultFields: DefaultFieldsResolver<User>;
+}
+interface UserFactoryInterface<TOptions extends UserFactoryDefineOptions> {
+  build(): Promise<ResolvedFields<TOptions['defaultFields']>>;
+  build<const T extends InputFieldsResolver<User>>(
+    inputFieldResolvers: T,
+    // eslint-disable-next-line @typescript-eslint/ban-types
+  ): Promise<Merge<ResolvedFields<TOptions['defaultFields']>, ResolvedFields<T>>>;
+  resetSequence(): void;
+}
+
+function defineUserFactoryInternal<const TOptions extends UserFactoryDefineOptions>({
+  defaultFields: defaultFieldResolvers,
+}: TOptions): UserFactoryInterface<TOptions> {
+  const seqKey = {};
+  const getSeq = () => getSequenceCounter(seqKey);
+  return {
+    async build<const T extends InputFieldsResolver<User>>(
+      inputFieldResolvers?: T,
+    ): Promise<Merge<ResolvedFields<TOptions['defaultFields']>, ResolvedFields<T>>> {
+      const seq = getSeq();
+      return resolveFields(seq, defaultFieldResolvers, inputFieldResolvers ?? ({} as T));
+    },
+    resetSequence() {
+      resetSequence(seqKey);
+    },
+  };
+}
+
+/**
+ * Define factory for {@link User} model.
+ *
+ * @param options
+ * @returns factory {@link UserFactoryInterface}
+ */
+export function defineUserFactory<TOptions extends UserFactoryDefineOptions>(
+  options: TOptions,
+): UserFactoryInterface<TOptions> {
+  return defineUserFactoryInternal(options);
 }


### PR DESCRIPTION
ref: #1

Dependent fields are inspired by [Dependent Attributes of FactoryBot](https://github.com/thoughtbot/factory_bot/blob/master/GETTING_STARTED.md#dependent-attributes). Also, `get` utility is inspired by [`get` utility of recoil selector](https://recoiljs.org/docs/basic-tutorial/selectors/).