### PR TITLE
Use `Lazy` class instead of raw function

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,6 @@
 import { expect, it, describe, assertType, expectTypeOf } from 'vitest';
 import { oneOf } from './test/util.js';
-import { defineBookFactory, type Book, resetAllSequence } from './index.js';
+import { defineBookFactory, type Book, resetAllSequence, lazy } from './index.js';
 
 describe('defineTypeFactory', () => {
   it('basic', async () => {
@@ -72,8 +72,8 @@ describe('defineTypeFactory', () => {
   it('accepts functional field resolvers', async () => {
     const BookFactory = defineBookFactory({
       defaultFields: {
-        id: () => 'Book-0',
-        title: async () => Promise.resolve('ゆゆ式'),
+        id: lazy(() => 'Book-0'),
+        title: lazy(async () => Promise.resolve('ゆゆ式')),
         author: undefined,
       },
     });
@@ -93,8 +93,8 @@ describe('defineTypeFactory', () => {
   it('creates fields with sequential id', async () => {
     const BookFactory = defineBookFactory({
       defaultFields: {
-        id: ({ seq }) => `Book-${seq}`,
-        title: async ({ seq }) => Promise.resolve(`ゆゆ式 ${seq}巻`),
+        id: lazy(({ seq }) => `Book-${seq}`),
+        title: lazy(async ({ seq }) => Promise.resolve(`ゆゆ式 ${seq}巻`)),
         author: undefined,
       },
     });
@@ -115,7 +115,7 @@ describe('defineTypeFactory', () => {
     it('resets all sequence', async () => {
       const BookFactory = defineBookFactory({
         defaultFields: {
-          id: ({ seq }) => `Book-${seq}`,
+          id: lazy(({ seq }) => `Book-${seq}`),
           title: 'ゆゆ式',
           author: undefined,
         },
@@ -227,8 +227,8 @@ describe('TypeFactoryInterface', () => {
         },
       });
       const book = await BookFactory.build({
-        id: () => 'Book-0',
-        title: async () => Promise.resolve('ゆゆ式'),
+        id: lazy(() => 'Book-0'),
+        title: lazy(async () => Promise.resolve('ゆゆ式')),
         author: undefined,
       });
       expect(book).toStrictEqual({
@@ -252,8 +252,8 @@ describe('TypeFactoryInterface', () => {
         },
       });
       const book = await BookFactory.build({
-        id: ({ seq }) => `Book-${seq}`,
-        title: async ({ seq }) => Promise.resolve(`ゆゆ式 ${seq}巻`),
+        id: lazy(({ seq }) => `Book-${seq}`),
+        title: lazy(async ({ seq }) => Promise.resolve(`ゆゆ式 ${seq}巻`)),
       });
       expect(book).toStrictEqual({
         id: 'Book-0',
@@ -272,7 +272,7 @@ describe('TypeFactoryInterface', () => {
     it('resets sequence', async () => {
       const BookFactory = defineBookFactory({
         defaultFields: {
-          id: ({ seq }) => `Book-${seq}`,
+          id: lazy(({ seq }) => `Book-${seq}`),
           title: 'ゆゆ式',
           author: undefined,
         },

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,9 +5,10 @@ import {
   type DefaultFieldsResolver,
   type InputFieldsResolver,
   resolveFields,
+  lazy,
 } from './util.js';
 
-export { resetAllSequence };
+export { resetAllSequence, lazy };
 
 export type Book = {
   id: string;

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -1,11 +1,12 @@
-import { expectTypeOf, it } from 'vitest';
+import { expect, expectTypeOf, it } from 'vitest';
 import {
   type DeepOptional,
   type FieldResolver,
   type ResolvedFields,
   type Merge,
   type ResolvedField,
-  FieldResolverOptions,
+  Lazy,
+  lazy,
 } from './util.js';
 
 it('DeepOptional', () => {
@@ -15,14 +16,31 @@ it('DeepOptional', () => {
   expectTypeOf<Actual>().toEqualTypeOf<Expected>();
 });
 
+it('Lazy', async () => {
+  const lazy1 = new Lazy(({ seq }) => `Book-${seq}`);
+  expect(await lazy1.get({ seq: 0 })).toBe('Book-0');
+
+  const lazy2 = new Lazy(async ({ seq }) => Promise.resolve(`Book-${seq}`));
+  expect(await lazy2.get({ seq: 0 })).toBe('Book-0');
+});
+
+it('lazy', async () => {
+  const l1 = lazy(({ seq }) => `Book-${seq}`);
+  expect(l1).instanceOf(Lazy);
+  expect(await l1.get({ seq: 0 })).toBe('Book-0');
+
+  const l2 = lazy(async ({ seq }) => Promise.resolve(`Book-${seq}`));
+  expect(l2).instanceOf(Lazy);
+  expect(await l2.get({ seq: 0 })).toBe('Book-0');
+});
+
 it('FieldResolver', () => {
-  expectTypeOf<FieldResolver<number>>().toEqualTypeOf<
-    number | ((options: FieldResolverOptions) => number) | ((options: FieldResolverOptions) => Promise<number>)
-  >();
+  expectTypeOf<FieldResolver<number>>().toEqualTypeOf<number | Lazy<number>>();
 });
 
 it('ResolvedField', () => {
-  expectTypeOf<ResolvedField<FieldResolver<number>>>().toEqualTypeOf<number>();
+  expectTypeOf<ResolvedField<number>>().toEqualTypeOf<number>();
+  expectTypeOf<ResolvedField<Lazy<number>>>().toEqualTypeOf<number>();
 });
 
 it('ResolvedFields', () => {


### PR DESCRIPTION
ref: #1 

Users can deserialize GraphQL custom scalar types to their favorite application types. Thus, the type of an application-level field can be any type.

For example, a custom scalar type can be deserialized into a function. However, graphql-fabbrica did not support it. graphql-fabbrica incorrectly interpreted a field deserialized into a function as a lazily evaluated field.

This PR introduces a lazy class so that graphql-fabbrica can distinguish between lazily evaluated fields and fields deserialized into functions.

## References
- https://graphql.org/learn/schema/#scalar-types
- https://www.apollographql.com/docs/apollo-server/schema/custom-scalars/